### PR TITLE
Locking node version to >= 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
         "ts-node": "^10.0.0",
         "ts-node-dev": "^1.1.6",
         "typescript": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -2382,7 +2385,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3355,8 +3357,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -5144,7 +5145,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.1",
         "jest-serializer": "^27.0.1",
@@ -9649,7 +9649,6 @@
       "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
       "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
       "dependencies": {
-        "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "validator": "^12.0.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
       "prettier --write"
     ]
   },
+  "engines": {
+    "node": ">=16"
+  },
   "devDependencies": {
     "@types/express": "^4.17.12",
     "@types/helmet": "^4.0.0",


### PR DESCRIPTION
## Proposed changes
--------------------
Locking node version to 16 or higher in the package json. This will prevent (some) discrepancies by keeping everyone on the same versions of things. 

## Types of changes
--------------------
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist
--------------------
- [x] My changeset covers only what is described above (no extraneous changes)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged downstream

## Further comments
--------------------
The changes to the package lock are because the project was created on node 15. 